### PR TITLE
Remove gUnusedBikeCameraAheadPanback; clean unreachable logic

### DIFF
--- a/docs/cleanup_log.md
+++ b/docs/cleanup_log.md
@@ -23,6 +23,19 @@ Tracking removal of verified unused symbols using `nm`, `ripgrep`, and `make`.
 
 ---
 
+#### Symbol: `gUnusedBikeCameraAheadPanback`
+- **Declared in:** `include/bike.h`
+- **Defined in:** `src/field_camera.c`, `src/bike.c`
+- **References:** Only used in conditionals that always evaluate the same way
+  - `nm pokeemerald.elf | grep gUnusedBikeCameraAheadPanback`
+  - `rg gUnusedBikeCameraAheadPanback`
+- ✅ Confirmed static `FALSE` initializer and no mutations
+- 🧹 Replaced all logic depending on this variable with constant branches
+- 🛠 Removed from both header and source
+- ✅ `make` succeeded post-removal
+
+---
+
 ### 📌 Notes
 - `nm` confirmed symbol was present in ELF before removal.
 - `make` was rerun after the edit to ensure ROM integrity.

--- a/include/bike.h
+++ b/include/bike.h
@@ -63,9 +63,6 @@ enum
     ACRO_TRANS_WHEELIE_LOWERING_MOVING,
 };
 
-// Exported RAM declarations
-extern bool8 gUnusedBikeCameraAheadPanback;
-
 // Exported ROM declarations
 void MovePlayerOnBike(u8 direction, u16 newKeys, u16 heldKeys);
 void Bike_TryAcroBikeHistoryUpdate(u16 newKeys, u16 heldKeys);

--- a/src/bike.c
+++ b/src/bike.c
@@ -973,8 +973,6 @@ bool8 IsPlayerNotUsingAcroBikeOnBumpySlope(void)
 
 void GetOnOffBike(u8 transitionFlags)
 {
-    gUnusedBikeCameraAheadPanback = FALSE;
-
     if (gPlayerAvatar.flags & (PLAYER_AVATAR_FLAG_MACH_BIKE | PLAYER_AVATAR_FLAG_ACRO_BIKE))
     {
         SetPlayerAvatarTransitionFlags(PLAYER_AVATAR_FLAG_ON_FOOT);

--- a/src/field_camera.c
+++ b/src/field_camera.c
@@ -12,8 +12,6 @@
 #include "sprite.h"
 #include "text.h"
 
-EWRAM_DATA bool8 gUnusedBikeCameraAheadPanback = FALSE;
-
 struct FieldCameraOffset
 {
     u8 xPixelOffset;
@@ -466,42 +464,5 @@ static void CameraPanningCB_PanAhead(void)
 {
     u8 var;
 
-    if (gUnusedBikeCameraAheadPanback == FALSE)
-    {
-        InstallCameraPanAheadCallback();
-    }
-    else
-    {
-        // this code is never reached
-        if (gPlayerAvatar.tileTransitionState == T_TILE_TRANSITION)
-        {
-            sBikeCameraPanFlag ^= 1;
-            if (sBikeCameraPanFlag == FALSE)
-                return;
-        }
-        else
-        {
-            sBikeCameraPanFlag = FALSE;
-        }
-
-        var = GetPlayerMovementDirection();
-        if (var == 2)
-        {
-            if (sVerticalCameraPan > -8)
-                sVerticalCameraPan -= 2;
-        }
-        else if (var == 1)
-        {
-            if (sVerticalCameraPan < 72)
-                sVerticalCameraPan += 2;
-        }
-        else if (sVerticalCameraPan < 32)
-        {
-            sVerticalCameraPan += 2;
-        }
-        else if (sVerticalCameraPan > 32)
-        {
-            sVerticalCameraPan -= 2;
-        }
-    }
+    InstallCameraPanAheadCallback();
 }


### PR DESCRIPTION
## Summary
- Removed unused variable `gUnusedBikeCameraAheadPanback`.
- Cleaned up conditional logic in `field_camera.c` and `bike.c`.
- Verified ELF exclusion via `nm` and `ripgrep`.
- Confirmed ROM builds and runtime behavior remain stable.

## Verification
- ✅ `make` succeeded without errors
- ✅ Verified removal from `.elf`
- ✅ Condition was unreachable due to constant assignment to `FALSE`

## References
- `docs/cleanup_log.md` updated with tracking entry
